### PR TITLE
refactor: remove duplicate code caught by `jscpd`

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,0 +1,130 @@
+import * as core from '@actions/core'
+import * as main from '../src/main'
+import * as utils from '../src/utils'
+
+/** URL of the comment made to first timer */
+export const createdCommentUrl = 'html_url.com'
+
+/** Number of action outputs */
+export const NUMBER_OF_ACTION_OUTPUTS = 4
+
+// Spy on the action's main function
+export const runSpy = jest.spyOn(main, 'run')
+
+// Spy on the acton's utils
+export const isFirstTimeContributorSpy = jest.spyOn(utils, 'isFirstTimeContributor')
+export const isSupportedEventSpy = jest.spyOn(utils, 'isSupportedEvent')
+export const getFCEventSpy = jest.spyOn(utils, 'getFCEvent')
+export const getActionInputsSpy = jest.spyOn(utils, 'getActionInputs')
+export const createCommentSpy = jest.spyOn(utils, 'createComment')
+export const addLabelsSpy = jest.spyOn(utils, 'addLabels')
+
+// Mock the GitHub Actions octokit client
+export const listForRepoMock = jest.fn()
+export const getOctokitMock = jest.fn().mockReturnValue({
+  rest: {
+    issues: {
+      addLabels: jest.fn(),
+      createComment: jest.fn().mockReturnValue({ data: { html_url: 'html_url.com' } }),
+      listForRepo: listForRepoMock
+    }
+  }
+})
+
+// Mock action inputs
+export const issueLabels = 'first timer'
+export const issueOpenedMsg = 'Thank you for reporting this issue.'
+export const issueCompletedMsg = 'Issue has been completed!'
+export const issueNotPlannedMsg = 'We are not going forward with this.'
+export const prLabels = 'first-contrib'
+export const prOpenedMsg = 'Thank you for opening this pull request.'
+export const prMergedMsg = 'This PR has been successfully merged!'
+export const prClosedMsg = 'PR was closed. Will not be merged'
+
+// Spy on and mock the GitHub Actions core library
+export const setOutputSpyMock = jest.spyOn(core, 'setOutput').mockImplementation()
+export const getInputSpyMock = jest.spyOn(core, 'getInput').mockImplementation(name => {
+  switch (name) {
+    case 'token':
+      return '***'
+    case 'issue-labels':
+      return issueLabels
+    case 'issue-opened-msg':
+      return issueOpenedMsg
+    case 'issue-completed-msg':
+      return issueCompletedMsg
+    case 'issue-not-planned-msg':
+      return issueNotPlannedMsg
+    case 'pr-labels':
+      return prLabels
+    case 'pr-opened-msg':
+      return prOpenedMsg
+    case 'pr-merged-msg':
+      return prMergedMsg
+    case 'pr-closed-msg':
+      return prClosedMsg
+    default:
+      return ''
+  }
+})
+
+// Functions
+export async function generalAssertions({ addedLabel }: { addedLabel: boolean }): Promise<void> {
+  expect(isSupportedEventSpy).toHaveReturnedWith(true)
+
+  expect(await isFirstTimeContributorSpy.mock.results[0].value)./* resolved value */ toBe(true)
+  expect(await createCommentSpy.mock.results[0].value)./* resolved value */ toBe(createdCommentUrl)
+  expect(await addLabelsSpy.mock.results[0].value)./* resolved value */ toBe(addedLabel)
+
+  expect(getInputSpyMock).toHaveBeenCalledTimes(['token', 'labels', 'msg'].length)
+  expect(setOutputSpyMock).toHaveBeenCalledTimes(NUMBER_OF_ACTION_OUTPUTS)
+
+  expect(runSpy).toHaveReturned()
+}
+
+export function githubIssueOpened({ isPullRequest }: { isPullRequest: boolean }): never {
+  listForRepoMock.mockReturnValue({ data: [{}] })
+
+  const event = isPullRequest ? 'pull_request' : 'issue'
+
+  return {
+    getOctokit: getOctokitMock,
+    context: {
+      eventName: isPullRequest ? 'pull_request' : 'issues',
+      repo: { owner: 'owner', repo: 'repo' },
+      payload: {
+        action: 'opened',
+        [event]: { number: 8, user: { login: 'ghosty' } }
+      }
+    }
+  } as never
+}
+
+export function githubIssueClosed(
+  opts:
+    | {
+        isPullRequest: false
+        state_reason: 'completed' | 'not_planned'
+      }
+    | {
+        isPullRequest: true
+        merged: boolean
+      }
+): never {
+  listForRepoMock.mockReturnValue({ data: [{ state: 'closed' }] })
+
+  const event = opts.isPullRequest ? 'pull_request' : 'issue'
+  const eventPayload = opts.isPullRequest ? { merged: opts.merged } : { state_reason: opts.state_reason }
+
+  return {
+    getOctokit: getOctokitMock,
+    context: {
+      eventName: opts.isPullRequest ? 'pull_request' : 'issues',
+      repo: { owner: 'owner', repo: 'repo' },
+      payload: {
+        action: 'closed',
+        [event]: { number: 8, user: { login: 'ghosty' }, ...eventPayload }
+      }
+    }
+  } as never
+}

--- a/__tests__/issues.test.ts
+++ b/__tests__/issues.test.ts
@@ -2,54 +2,19 @@
  * Unit tests for the `issues` event.
  */
 
-import * as core from '@actions/core'
 import * as main from '../src/main'
-import * as utils from '../src/utils'
-
-/** Number of action outputs */
-const NUMBER_OF_OUTPUTS = 4
-
-// Spy on the action's main function
-const runSpy = jest.spyOn(main, 'run')
-
-// Spy on the acton's utils
-const isFirstTimeContributorSpy = jest.spyOn(utils, 'isFirstTimeContributor')
-const isSupportedEventSpy = jest.spyOn(utils, 'isSupportedEvent')
-const getFCEventSpy = jest.spyOn(utils, 'getFCEvent')
-const getActionInputsSpy = jest.spyOn(utils, 'getActionInputs')
-const createCommentSpy = jest.spyOn(utils, 'createComment')
-const addLabelsSpy = jest.spyOn(utils, 'addLabels')
-
-// Mock the GitHub Actions octokit client
-const listForRepoMock = jest.fn()
-const getOctokitMock = jest.fn().mockReturnValue({
-  rest: {
-    issues: {
-      addLabels: jest.fn(),
-      createComment: jest.fn().mockReturnValue({ data: { html_url: 'html_url.com' } }),
-      listForRepo: listForRepoMock
-    }
-  }
-})
-
-// Spy on and mock the GitHub Actions core library
-const setOutputSpyMock = jest.spyOn(core, 'setOutput').mockImplementation()
-const getInputSpyMock = jest.spyOn(core, 'getInput').mockImplementation(name => {
-  switch (name) {
-    case 'token':
-      return '***'
-    case 'issue-labels':
-      return 'first timer'
-    case 'issue-opened-msg':
-      return 'Thank you for reporting this issue.'
-    case 'issue-completed-msg':
-      return 'Issue has been completed!'
-    case 'issue-not-planned-msg':
-      return 'pr-closed-msg'
-    default:
-      return ''
-  }
-})
+import {
+  generalAssertions,
+  getActionInputsSpy,
+  getFCEventSpy,
+  githubIssueClosed,
+  githubIssueOpened,
+  issueCompletedMsg,
+  issueLabels,
+  issueNotPlannedMsg,
+  issueOpenedMsg,
+  listForRepoMock
+} from './helpers'
 
 describe('issues', () => {
   beforeEach(() => {
@@ -58,104 +23,44 @@ describe('issues', () => {
 
   describe('.opened', () => {
     it('handle when a new issue is opened', async () => {
-      listForRepoMock.mockReturnValue({ data: [{}] })
-      const github = {
-        getOctokit: getOctokitMock,
-        context: {
-          eventName: 'issues',
-          repo: { owner: 'owner', repo: 'repo' },
-          payload: {
-            action: 'opened',
-            issue: { number: 8, user: { login: 'ghosty' } }
-          }
-        }
-      } as never
-
+      const github = githubIssueOpened({ isPullRequest: false })
       await main.run(github)
 
-      expect(isSupportedEventSpy).toHaveReturnedWith(true)
       expect(getFCEventSpy).toHaveReturnedWith({ name: 'issue', state: 'opened' })
       expect(getActionInputsSpy).toHaveReturnedWith({
-        labels: ['first timer'],
-        msg: 'Thank you for reporting this issue.'
+        labels: [issueLabels],
+        msg: issueOpenedMsg
       })
 
-      expect(await isFirstTimeContributorSpy.mock.results[0].value)./* resolved value */ toBe(true)
-      expect(await createCommentSpy.mock.results[0].value)./* resolved value */ toBe('html_url.com')
-      expect(await addLabelsSpy.mock.results[0].value)./* resolved value */ toBe(true)
-
-      expect(getInputSpyMock).toHaveBeenCalledTimes(['token', 'issue-labels', 'issue-opened-msg'].length)
-      expect(setOutputSpyMock).toHaveBeenCalledTimes(NUMBER_OF_OUTPUTS)
-
-      expect(runSpy).toHaveReturned()
+      await generalAssertions({ addedLabel: true })
     })
   })
 
   describe('.closed', () => {
     it('handle when an issue is closed as completed', async () => {
-      listForRepoMock.mockReturnValue({ data: [{ state: 'closed' }] })
-      const github = {
-        getOctokit: getOctokitMock,
-        context: {
-          eventName: 'issues',
-          repo: { owner: 'owner', repo: 'repo' },
-          payload: {
-            action: 'closed',
-            issue: { number: 9, user: { login: 'ghosty' }, state_reason: 'completed' }
-          }
-        }
-      } as never
-
+      const github = githubIssueClosed({ isPullRequest: false, state_reason: 'completed' })
       await main.run(github)
 
-      expect(isSupportedEventSpy).toHaveReturnedWith(true)
       expect(getFCEventSpy).toHaveReturnedWith({ name: 'issue', state: 'completed' })
       expect(getActionInputsSpy).toHaveReturnedWith({
-        labels: ['first timer'],
-        msg: 'Issue has been completed!'
+        labels: [issueLabels],
+        msg: issueCompletedMsg
       })
 
-      expect(await isFirstTimeContributorSpy.mock.results[0].value)./* resolved value */ toBe(true)
-      expect(await createCommentSpy.mock.results[0].value)./* resolved value */ toBe('html_url.com')
-      expect(await addLabelsSpy.mock.results[0].value)./* resolved value */ toBe(false)
-
-      expect(getInputSpyMock).toHaveBeenCalledTimes(['token', 'labels', 'msg'].length)
-      expect(setOutputSpyMock).toHaveBeenCalledTimes(NUMBER_OF_OUTPUTS)
-
-      expect(runSpy).toHaveReturned()
+      await generalAssertions({ addedLabel: false })
     })
 
     it('handle when an issue is closed as not planned', async () => {
-      listForRepoMock.mockReturnValue({ data: [{ state: 'closed' }] })
-      const github = {
-        getOctokit: getOctokitMock,
-        context: {
-          eventName: 'issues',
-          repo: { owner: 'owner', repo: 'repo' },
-          payload: {
-            action: 'closed',
-            issue: { number: 9, user: { login: 'ghosty' }, state_reason: 'not_planned' }
-          }
-        }
-      } as never
-
+      const github = githubIssueClosed({ isPullRequest: false, state_reason: 'not_planned' })
       await main.run(github)
 
-      expect(isSupportedEventSpy).toHaveReturnedWith(true)
       expect(getFCEventSpy).toHaveReturnedWith({ name: 'issue', state: 'not-planned' })
       expect(getActionInputsSpy).toHaveReturnedWith({
-        labels: ['first timer'],
-        msg: ''
+        labels: [issueLabels],
+        msg: issueNotPlannedMsg
       })
 
-      expect(await isFirstTimeContributorSpy.mock.results[0].value)./* resolved value */ toBe(true)
-      expect(await createCommentSpy.mock.results[0].value)./* resolved value */ toBe('')
-      expect(await addLabelsSpy.mock.results[0].value)./* resolved value */ toBe(false)
-
-      expect(getInputSpyMock).toHaveBeenCalledTimes(['token', 'labels', 'msg', 'msg-symlink'].length)
-      expect(setOutputSpyMock).toHaveBeenCalledTimes(NUMBER_OF_OUTPUTS)
-
-      expect(runSpy).toHaveReturned()
+      await generalAssertions({ addedLabel: false })
     })
   })
 })

--- a/__tests__/pull_request.test.ts
+++ b/__tests__/pull_request.test.ts
@@ -2,54 +2,19 @@
  * Unit tests for the `pull_request` and `pull_request_target` events.
  */
 
-import * as core from '@actions/core'
 import * as main from '../src/main'
-import * as utils from '../src/utils'
-
-/** Number of action outputs */
-const NUMBER_OF_OUTPUTS = 4
-
-// Spy on the action's main function
-const runSpy = jest.spyOn(main, 'run')
-
-// Spy on the acton's utils
-const isFirstTimeContributorSpy = jest.spyOn(utils, 'isFirstTimeContributor')
-const isSupportedEventSpy = jest.spyOn(utils, 'isSupportedEvent')
-const getFCEventSpy = jest.spyOn(utils, 'getFCEvent')
-const getActionInputsSpy = jest.spyOn(utils, 'getActionInputs')
-const createCommentSpy = jest.spyOn(utils, 'createComment')
-const addLabelsSpy = jest.spyOn(utils, 'addLabels')
-
-// Mock the GitHub Actions octokit client
-const listForRepoMock = jest.fn()
-const getOctokitMock = jest.fn().mockReturnValue({
-  rest: {
-    issues: {
-      addLabels: jest.fn(),
-      createComment: jest.fn().mockReturnValue({ data: { html_url: 'html_url.com' } }),
-      listForRepo: listForRepoMock
-    }
-  }
-})
-
-// Spy on and mock the GitHub Actions core library
-const setOutputSpyMock = jest.spyOn(core, 'setOutput').mockImplementation()
-const getInputSpyMock = jest.spyOn(core, 'getInput').mockImplementation(name => {
-  switch (name) {
-    case 'token':
-      return '***'
-    case 'pr-labels':
-      return 'first-contrib'
-    case 'pr-opened-msg':
-      return 'Thank you for opening this pull request.'
-    case 'pr-merged-msg':
-      return 'This PR has been successfully merged!'
-    case 'pr-closed-msg':
-      return 'PR was closed. Will not be merged'
-    default:
-      return ''
-  }
-})
+import {
+  generalAssertions,
+  getActionInputsSpy,
+  getFCEventSpy,
+  githubIssueClosed,
+  githubIssueOpened,
+  listForRepoMock,
+  prClosedMsg,
+  prLabels,
+  prMergedMsg,
+  prOpenedMsg
+} from './helpers'
 
 describe('pull_request', () => {
   beforeEach(() => {
@@ -58,104 +23,44 @@ describe('pull_request', () => {
 
   describe('.opened', () => {
     it('handle when a new pull request is opened', async () => {
-      listForRepoMock.mockReturnValue({ data: [{}] })
-      const github = {
-        getOctokit: getOctokitMock,
-        context: {
-          eventName: 'pull_request',
-          repo: { owner: 'owner', repo: 'repo' },
-          payload: {
-            action: 'opened',
-            pull_request: { number: 8, user: { login: 'ghosty' } }
-          }
-        }
-      } as never
-
+      const github = githubIssueOpened({ isPullRequest: true })
       await main.run(github)
 
-      expect(isSupportedEventSpy).toHaveReturnedWith(true)
       expect(getFCEventSpy).toHaveReturnedWith({ name: 'pr', state: 'opened' })
       expect(getActionInputsSpy).toHaveReturnedWith({
-        labels: ['first-contrib'],
-        msg: 'Thank you for opening this pull request.'
+        labels: [prLabels],
+        msg: prOpenedMsg
       })
 
-      expect(await isFirstTimeContributorSpy.mock.results[0].value)./* resolved value */ toBe(true)
-      expect(await createCommentSpy.mock.results[0].value)./* resolved value */ toBe('html_url.com')
-      expect(await addLabelsSpy.mock.results[0].value)./* resolved value */ toBe(true)
-
-      expect(getInputSpyMock).toHaveBeenCalledTimes(['token', 'labels', 'msg'].length)
-      expect(setOutputSpyMock).toHaveBeenCalledTimes(NUMBER_OF_OUTPUTS)
-
-      expect(runSpy).toHaveReturned()
+      await generalAssertions({ addedLabel: true })
     })
   })
 
   describe('.closed', () => {
     it('handle when a pull request is merged', async () => {
-      listForRepoMock.mockReturnValue({ data: [{ state: 'closed' }] })
-      const github = {
-        getOctokit: getOctokitMock,
-        context: {
-          eventName: 'pull_request',
-          repo: { owner: 'owner', repo: 'repo' },
-          payload: {
-            action: 'closed',
-            pull_request: { number: 8, user: { login: 'ghosty' }, merged: true }
-          }
-        }
-      } as never
-
+      const github = githubIssueClosed({ isPullRequest: true, merged: true })
       await main.run(github)
 
-      expect(isSupportedEventSpy).toHaveReturnedWith(true)
       expect(getFCEventSpy).toHaveReturnedWith({ name: 'pr', state: 'merged' })
       expect(getActionInputsSpy).toHaveReturnedWith({
-        labels: ['first-contrib'],
-        msg: 'This PR has been successfully merged!'
+        labels: [prLabels],
+        msg: prMergedMsg
       })
 
-      expect(await isFirstTimeContributorSpy.mock.results[0].value)./* resolved value */ toBe(true)
-      expect(await createCommentSpy.mock.results[0].value)./* resolved value */ toBe('html_url.com')
-      expect(await addLabelsSpy.mock.results[0].value)./* resolved value */ toBe(false)
-
-      expect(getInputSpyMock).toHaveBeenCalledTimes(['token', 'labels', 'msg'].length)
-      expect(setOutputSpyMock).toHaveBeenCalledTimes(NUMBER_OF_OUTPUTS)
-
-      expect(runSpy).toHaveReturned()
+      await generalAssertions({ addedLabel: false })
     })
 
     it('handle when a pull request is closed WITHOUT being merged', async () => {
-      listForRepoMock.mockReturnValue({ data: [{ state: 'closed' }] })
-      const github = {
-        getOctokit: getOctokitMock,
-        context: {
-          eventName: 'pull_request',
-          repo: { owner: 'owner', repo: 'repo' },
-          payload: {
-            action: 'closed',
-            pull_request: { number: 9, user: { login: 'ghosty' }, merged: false }
-          }
-        }
-      } as never
-
+      const github = githubIssueClosed({ isPullRequest: true, merged: false })
       await main.run(github)
 
-      expect(isSupportedEventSpy).toHaveReturnedWith(true)
       expect(getFCEventSpy).toHaveReturnedWith({ name: 'pr', state: 'closed' })
       expect(getActionInputsSpy).toHaveReturnedWith({
-        labels: ['first-contrib'],
-        msg: 'PR was closed. Will not be merged'
+        labels: [prLabels],
+        msg: prClosedMsg
       })
 
-      expect(await isFirstTimeContributorSpy.mock.results[0].value)./* resolved value */ toBe(true)
-      expect(await createCommentSpy.mock.results[0].value)./* resolved value */ toBe('html_url.com')
-      expect(await addLabelsSpy.mock.results[0].value)./* resolved value */ toBe(false)
-
-      expect(getInputSpyMock).toHaveBeenCalledTimes(['token', 'labels', 'msg'].length)
-      expect(setOutputSpyMock).toHaveBeenCalledTimes(NUMBER_OF_OUTPUTS)
-
-      expect(runSpy).toHaveReturned()
+      await generalAssertions({ addedLabel: false })
     })
   })
 })


### PR DESCRIPTION
Also added a `helper.ts` file for common variables and chunks of code